### PR TITLE
Update VS Code extension links

### DIFF
--- a/fsh-seminar/input/pagecontent/02-creating-an-ig.md
+++ b/fsh-seminar/input/pagecontent/02-creating-an-ig.md
@@ -121,7 +121,7 @@ By default, SUSHI generates a placeholder `input/pagecontent/index.md` file that
 
 #### Recommended tools for IG authoring
 
-The [prerequisites](prerequisites.html) for this course include installing [Visual Studio Code (VSCode)](https://code.visualstudio.com) and the [FSH language extension](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh). While you can use any text editor to edit FSH (`.fsh`) files, currently only VSCode has syntax highlighting and other language-specific features via the custom language extension.
+The [prerequisites](prerequisites.html) for this course include installing [Visual Studio Code (VSCode)](https://code.visualstudio.com) and the [FSH language extension](https://marketplace.visualstudio.com/items?itemName=MITRE-Health.vscode-language-fsh). While you can use any text editor to edit FSH (`.fsh`) files, currently only VSCode has syntax highlighting and other language-specific features via the custom language extension.
 
 VSCode also [supports editing Markdown out of the box](https://code.visualstudio.com/docs/languages/markdown) (Markdown is used very widely outside of the FHIR/HL7 world), and if you follow that link you will see some additional Markdown extensions that are available if you want additional functionality (like "linting", which will warn you of syntax errors as you type). One of the most useful VSCode features is [built-in Markdown previewing](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview).
 

--- a/fsh-seminar/input/pagecontent/03-exercise.md
+++ b/fsh-seminar/input/pagecontent/03-exercise.md
@@ -68,7 +68,7 @@ The use case for this work is as follows:
 - If you just want to quickly test how to represent and validate a contained construct in FSH without having to run the IG publisher, try it using [FSHOnline](https://fshschool.org/FSHOnline/#/)
 - Want to see more FSH examples? Go to [FSHOnline](https://fshschool.org/FSHOnline/#/) and click on the "FSH Examples".
 - Want to see how another IG's StructureDefinitions in JSON could be represented in FSH? Also try it using [FSHOnline](https://fshschool.org/FSHOnline/#/). Cut and paste your JSON into the right column and click on _Convert to FSH_ to see the syntax.
-- Try using some of the nice perks in the [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh) extension to help navigate references between your authored FHIR constructs (profiles, value sets, extensions, etc.)
+- Try using some of the nice perks in the [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=MITRE-Health.vscode-language-fsh) extension to help navigate references between your authored FHIR constructs (profiles, value sets, extensions, etc.)
 - Other neat VSCode extensions to help create a more authoring-friendly VSCode environment:
     - [Markdown Preview Github Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles) - provides a basic dynamic rendering of your markdown page while you type (but note that embedded images won't be rendered in the preview due to the directory structure).
     - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio) - integrates Draw.io/diagrams.net into VSCode so that you can create nice diagrams directly inside your IG authoring environment

--- a/fsh-seminar/input/pagecontent/setup.md
+++ b/fsh-seminar/input/pagecontent/setup.md
@@ -6,7 +6,7 @@
 
 As part of this course, you will edit and build a FHIR Implementation Guide on your computer. To do this, you will need the following:
 
-1. Install [Visual Studio Code](https://code.visualstudio.com) and the [FSH language extension](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh)
+1. Install [Visual Studio Code](https://code.visualstudio.com) and the [FSH language extension](https://marketplace.visualstudio.com/items?itemName=MITRE-Health.vscode-language-fsh)
 2. Install a Java runtime
 3. Install Ruby and Jekyll using [these OS-specific instructions](https://jekyllrb.com/docs/installation/#guides)
 4. Install SUSHI using [these directions](https://fshschool.org/docs/sushi/installation/)


### PR DESCRIPTION
Small PR to update the links to the FSH VS Code extension. The links now point to the current extension.